### PR TITLE
Adds basic renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+    "extends": [
+        "config:base",
+        "github>ExpediaGroup/renovate-config-catalyst:semanticCommits"
+    ]
+}


### PR DESCRIPTION
This PR adds a basic Renovate config file.

The renovate config extends config extends the semantic commits preset defined here: https://github.com/ExpediaGroup/renovate-config-catalyst