### PR TITLE
fix(release workflow): Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Add NODE_AUTH_TOKEN env variable similar to [this repo](https://github.com/ExpediaGroup/graphql-component/blob/master/.github/workflows/npmpublish.yml#L34) to see if it will fix the release workflow which currently fails during the npm publish stage.