### PR TITLE
Breaking Change: Enable raw output for file-rotation-only cases

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,11 @@ function start (config) {
     if (result && outputStream) {
       debug('logging to %s', output.path)
       // if filtered by config, output to rotating file
-      setImmediate(() => { outputStream.write(`${JSON.stringify(data)}\n`, 'utf8', cb) })
+      if (output && output.isJson === false) {
+        setImmediate(() => { outputStream.write(data + '\n', 'utf8', cb) })
+      } else {
+        setImmediate(() => { outputStream.write(`${JSON.stringify(data)}\n`, 'utf8', cb) })
+      }
     } else {
       // otherwise send out stdout and do not block the loop.
       if (output && output.isJson === false) {


### PR DESCRIPTION
Closes #27

Previously, when logging entries run through `pino-pretty`, the output is wrapped in double-quotes on each line:
```
"[2021-02-23 22:10:29.888 +0000] INFO (myLabel): my log {"
"    req: {"
"        url: '/'"
"    }"
"[2021-02-23 22:10:29.999 +0000] ERROR (myLabel): TypeError: my error log"
"    at line 42"
...
```
Which would then require additional configurations for Splunk indexers to correctly parse the log.

Preferably in this case, it would just log the output as-is, without calling `JSON.stringify()` on it, like it is now.

These changes wrap the call to the output stream in a similar check for `isJson === false` that is happening in other use-cases, so that the raw `data` value will get passed directly to the destination stream, rather than first calling `${JSON.stringify(data)}\n`.