### PR TITLE
Feat: Enable raw output for file-rotation-only cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,38 @@ module.exports = {
   }
 }
 ```
+Additionally, if `isJson === false` and your logs are getting wrapped in quotes, like if you are using `pino-pretty` and your logs look like this:
+```
+"[2021-02-23 22:10:29.888 +0000] INFO (myLabel): my log {"
+"    req: {"
+"        url: '/'"
+"    }"
+"[2021-02-23 22:10:29.999 +0000] ERROR (myLabel): TypeError: my error log"
+"    at line 42"
+...
+```
+You can optionally add `isRawOutput: true` to pass the raw value directly to the output stream, so your output doesn't get stringified on the way:
+```javascript
+module.exports = {
+  filter(data) {return !!data.req},
+  output: {
+    path: "request.log",
+    isJson: false // JSON formatting will be disabled,
+    isRawOutput: true // Raw data passed to output stream,
+    options: { ... }
+  }
+}
+```
+This outputs:
+```
+[2021-02-23 22:10:29.888 +0000] INFO (myLabel): my log {
+    req: {
+        url: '/'
+    }
+[2021-02-23 22:10:29.999 +0000] ERROR (myLabel): TypeError: my error log
+    at line 42
+...
+``` 
 
 ## Further Reading
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,7 +86,14 @@ function start (config) {
     if (result && outputStream) {
       debug('logging to %s', output.path)
       // if filtered by config, output to rotating file
-      setImmediate(() => { outputStream.write(`${JSON.stringify(data)}\n`, 'utf8', cb) })
+      if (output && output.isRawOutput === true && output.isJson === false) {
+        setImmediate(() => { outputStream.write(data + '\n', 'utf8', cb) })
+      } else {
+        if (output && output.isRawOutput === true) {
+          process.stderr.write('Writing raw output with option "isRawOutput", when "isJson" is "true", would write "[object Object]" to file. (treating as JSON)')
+        }
+        setImmediate(() => { outputStream.write(`${JSON.stringify(data)}\n`, 'utf8', cb) })
+      }
     } else {
       // otherwise send out stdout and do not block the loop.
       if (output && output.isJson === false) {


### PR DESCRIPTION
Previously, when logging entries run through `pino-pretty`, the output is wrapped in double-quotes on each line:
```
"[2021-02-23 22:10:29.888 +0000] INFO (myLabel): my log {"
"    req: {"
"        url: '/'"
"    }"
"[2021-02-23 22:10:29.999 +0000] ERROR (myLabel): TypeError: my error log"
"    at line 42"
...
```
Which would then require additional configurations for Splunk indexers to correctly parse the log.

Preferably in this case, it would just log the output as-is, without calling `JSON.stringify()` on it, like it is now.

These changes introduce an additional configuration option `isRawOutput`, that will operate similarly to `isJson`, in that it will pass its value directly to its destination rather than calling `${JSON.stringify(data)}\n`. Likewise, it only makes sense to run inconjuction with `isJson`, since the output would otherwise be `[object Object]\n` in the destination file, so an error is thrown to point users to add `isJson: false` if they want to make use of `isRawOutput`.