### PR TITLE
fix: Altering the order of semantic release config file to have it correct

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,13 +4,13 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
+    "@semantic-release/npm",
     [
       "@semantic-release/git",
       {
         "message": "${nextRelease.version} CHANGELOG [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/npm",
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
[CAT-1548](https://jira.expedia.biz/browse/CAT-1548)

Modifying order of the imports for the semantic release to add correctly the version on the package, this fix where commented here:

https://github.com/semantic-release/semantic-release/issues/1593#issuecomment-656866839

Tested changes on my fork repo:
https://github.com/YosafatEG/steerage